### PR TITLE
Updated scala, pact and spring versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,22 @@
 name := "pact-jvm-provider-spring-mvc"
 
-version := "0.4.0"
+version := "0.5.0"
 
 organization := "com.reagroup"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.10.4", "2.11.4")
 
-sbtVersion := "0.13.7"
+sbtVersion := "0.13.11"
 
 libraryDependencies ++= Seq(
-  "au.com.dius" %% "pact-jvm-model" % "2.1.13",
-  "au.com.dius" %% "pact-jvm-consumer-junit" % "2.1.13",
-  "org.springframework" % "spring-test" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-webmvc" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-context" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-core" % "4.1.3.RELEASE",
+  "au.com.dius" %% "pact-jvm-model" % "3.2.12",
+  "au.com.dius" %% "pact-jvm-consumer-junit" % "3.2.12",
+  "org.springframework" % "spring-test" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-webmvc" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-context" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-core" % "4.3.2.RELEASE",
   "junit" % "junit" % "4.12",
   "org.skyscreamer" % "jsonassert" % "1.2.3",
   "javax.servlet" % "javax.servlet-api" % "3.0.1",
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 )
 
 // publish to sonatype
-import SonatypeKeys._
+import xerial.sbt.Sonatype.SonatypeKeys._
 
 sonatypeSettings
 

--- a/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
@@ -1,11 +1,9 @@
 package com.reagroup.pact.provider
 
-import java.io.InputStreamReader
-
-import au.com.dius.pact.model.{Interaction, Pact}
+import au.com.dius.pact.model.{Interaction, PactReader}
 import org.springframework.core.io.{DefaultResourceLoader, Resource}
-import org.springframework.util.FileCopyUtils
 
+import scala.collection.JavaConversions.asScalaBuffer
 import scala.util.{Failure, Success, Try}
 
 trait InteractionFileReader {
@@ -13,7 +11,7 @@ trait InteractionFileReader {
   val testClass: Class[_]
 
   lazy val allInteractions: Seq[Interaction] = getPactFile(testClass) match {
-    case Success(pactFile) => Pact.from(readToString(pactFile)).interactions
+    case Success(pactFile) => asScalaBuffer(PactReader.loadPact(pactFile.getInputStream).getInteractions).toList
     case Failure(e) => throw e
   }
 
@@ -22,10 +20,5 @@ trait InteractionFileReader {
       .map(pactFile => Success(new DefaultResourceLoader().getResource(pactFile.value)))
       .getOrElse(Failure(new IllegalStateException("Please use @PactFile to specify the pact file resource")))
   }
-
-  private def readToString(resource: Resource) = {
-    FileCopyUtils.copyToString(new InputStreamReader(resource.getInputStream, "UTF-8"))
-  }
-
 }
 

--- a/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
@@ -1,48 +1,64 @@
 package com.reagroup.pact.provider
 
-import au.com.dius.pact.model.{Interaction, Response}
+import au.com.dius.pact.model.v3.messaging.Message
+import au.com.dius.pact.model.{Interaction, RequestResponseInteraction, Response}
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders._
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers._
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.{request, _}
 import org.springframework.test.web.servlet.setup.MockMvcBuilders._
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.Try
 
 trait InteractionRunner {
   this: InteractionFileReader =>
 
   def findInteractions(providerState: String): Seq[Interaction] = {
-    allInteractions.filter(_.providerState.exists(_ == providerState))
+    allInteractions.filter(_.getProviderState == providerState)
   }
 
-  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
-    RequestMatcherBuilder.build(interaction.request).map { requestBuilder =>
+  def runReqResponse(interaction: RequestResponseInteraction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
+    RequestMatcherBuilder.build(interaction.getRequest).map { requestBuilder =>
       timeout match {
-        case Some(t) => {
+        case Some(t) =>
           val server = standaloneSetup(controller).setAsyncRequestTimeout(t).build()
           val asyncStarted = server.perform(requestBuilder).andExpect(request.asyncStarted).andReturn()
           val response = server.perform(asyncDispatch(asyncStarted))
-          responseMatchers(interaction.response).foreach(response.andExpect)
-        }
-        case None => {
+          responseMatchers(interaction.getResponse).foreach(response.andExpect)
+        case None =>
           val server = standaloneSetup(controller).build()
           val response = server.perform(requestBuilder)
-          responseMatchers(interaction.response).foreach(response.andExpect)
-        }
+          println(response)
+          responseMatchers(interaction.getResponse).foreach(response.andExpect)
       }
     }
   }
 
-  private def responseMatchers(response: Response): Seq[ResultMatcher] = {
-    def matchResStatus(response: Response) = status.is(response.status)
-    def matchResBodyAsJson(response: Response) = response.body.map(body => content.json(body))
-    def matchResHeaders(response: Response) = for {
-      headers <- response.headers.toList
-      (name, value) <- headers
-    } yield header.string(name, value)
+  def runMsq(interaction: Message, controller: AnyRef, timeout: Option[Long] = None) = ???
 
-    matchResStatus(response) :: matchResBodyAsJson(response).toList ::: matchResHeaders(response)
+  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
+    interaction match {
+      case requestResponse: RequestResponseInteraction =>
+        runReqResponse(requestResponse, controller, timeout);
+      case msg: Message =>
+        runMsq(msg, controller, timeout);
+    }
+  }
+
+  private def responseMatchers(response: Response): Seq[ResultMatcher] = {
+    def matchResStatus(response: Response)= status.is(response.getStatus)
+    def matchResBodyAsJson(response: Response) = Option(response.getBody.getValue).map(body => content().json(body))
+    def matchResHeaders(response: Response) = {
+      Option(response.getHeaders) match {
+        case None => mutable.Seq.empty
+        case Some(h) => for {
+          headers: (String, String) <- h.asScala
+        } yield header.string(headers._1, headers._2)
+      }
+    }
+
+    matchResStatus(response) :: matchResBodyAsJson(response).toList ::: matchResHeaders(response).toList
   }
 
 }

--- a/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
+++ b/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders._
 import org.springframework.web.util.{UriComponents, UriComponentsBuilder}
 
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 object RequestMatcherBuilder {
@@ -23,16 +24,31 @@ object RequestMatcherBuilder {
   }
 
   private def buildUriComponents(request: Request) = {
-    def decode(s: String) = URLDecoder.decode(s, "UTF-8")
+    def decode(s: String) = {
+      Option(s) match {
+        case Some(q) => URLDecoder.decode(q, "UTF-8")
+        case None => null
+      }
+    }
+
+    def toQuery(map: java.util.Map[String, java.util.List[String]]): String = {
+      Option(map) match {
+        case Some(q) => (for {
+          m <- q.asScala
+        } yield m._1 + "=" + m._2.asScala.map(URLDecoder.decode(_, "UTF-8")).mkString(";")).mkString("&")
+        case None => null
+      }
+    }
+
     UriComponentsBuilder
-      .fromUriString(decode(request.path))
-      .query(request.query.map(decode).getOrElse(""))
+      .fromUriString(decode(request.getPath))
+      .query(decode(toQuery(request.getQuery)))
       .build
   }
 
   private def createBuilderByHttpMethod(request: Request, components: UriComponents): Try[MockHttpServletRequestBuilder] = {
     val uri = components.toUri
-    request.method.toLowerCase match {
+    request.getMethod.toLowerCase match {
       case "get" => Success(get(uri))
       case "post" => Success(post(uri))
       case "put" => Success(put(uri))
@@ -44,20 +60,29 @@ object RequestMatcherBuilder {
   }
 
   private def buildReqBody(builder: MockHttpServletRequestBuilder, request: Request): Unit = {
-    request.body.foreach(body => builder.content(body))
+    Option(request.getBody) match {
+      case Some(b) => builder.content(b.orElse(""))
+      case None =>
+    }
   }
 
-  private def buildReqHeaders(builder: MockHttpServletRequestBuilder, request: Request): Unit = for {
-    headers <- request.headers
-    (name, value) <- headers
-  } builder.header(name, value)
+  private def buildReqHeaders(builder: MockHttpServletRequestBuilder, request: Request): Unit = {
+    Option(request.getHeaders) match {
+      case Some(h) => for {
+        headers: (String, String) <- h.asScala
+      } builder.header(headers._1, headers._2)
+      case None =>
+    }
+  }
 
   private def buildCookies(builder: MockHttpServletRequestBuilder, request: Request, components: UriComponents): Unit = {
-    request.cookie.getOrElse(Nil).map(_.split('=')).collect {
-      case Array(key, value) => new Cookie(key, value)
-    } match {
-      case Nil =>
-      case cookies => builder.cookie(cookies: _*)
+    Option(request.cookie()) match {
+      case Some(c) => c.asScala.map(_.split('=')).collect {
+        case Array(key, value) => new Cookie(key, value)
+      } match {
+        case cookies => builder.cookie(cookies: _*)
+      }
+      case None =>
     }
   }
 

--- a/src/test/java/sample/MyController.java
+++ b/src/test/java/sample/MyController.java
@@ -19,7 +19,7 @@ public class MyController {
 
     @RequestMapping(value = "/deferred_json", method = RequestMethod.GET, consumes = "application/json", produces = "application/json;charset=UTF-8")
     public DeferredResult<ResponseEntity<String>> defJson() {
-        DeferredResult<ResponseEntity<String>> result = new DeferredResult<ResponseEntity<String>>(50);
+        DeferredResult<ResponseEntity<String>> result = new DeferredResult<>(50L);
         ResponseEntity<String> response = myResponseService.getResponse();
         result.setResult(response);
         return result;

--- a/src/test/resources/interactions.json
+++ b/src/test/resources/interactions.json
@@ -98,5 +98,10 @@
         }
       }
     }
-  ]
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    }
+  }
 }

--- a/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
@@ -11,7 +11,7 @@ class InteractionFileReaderTest extends Specification with Mockito {
     "read interactions from the JSON file" in {
       val reader = createReader(classOf[TestClass])
       reader.allInteractions must have length 5
-      reader.allInteractions.map(_.providerState) === Seq(Some("normal"), Some("deferred"), Some("with-headers"), Some("with-cookies"), Some("with-array-body"))
+      reader.allInteractions.map(_.getProviderState) === Seq("normal", "deferred", "with-headers", "with-cookies", "with-array-body")
     }
     "should report error if file is not found" in {
       val reader = createReader(classOf[TestClassWithFileNotFound])

--- a/src/test/scala/com/reagroup/pact/provider/InteractionRunnerTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/InteractionRunnerTest.scala
@@ -1,6 +1,6 @@
 package com.reagroup.pact.provider
 
-import au.com.dius.pact.model.{Interaction, Request, Response}
+import au.com.dius.pact.model.{Interaction, Request, RequestResponseInteraction, Response}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
@@ -9,16 +9,16 @@ class InteractionRunnerTest extends Specification with Mockito {
   "InteractionRunner" should {
     "find interactions by provider state" in {
       val interactions = Seq(
-        Interaction("desc1", Some("providerState1"), mock[Request], mock[Response]),
-        Interaction("desc2", Some("providerState2"), mock[Request], mock[Response]))
+        new RequestResponseInteraction("desc1", "providerState1", mock[Request], mock[Response]),
+        new RequestResponseInteraction("desc2", "providerState2", mock[Request], mock[Response]))
       val runner = createRunner(interactions)
 
       val found = runner.findInteractions("providerState2")
       found must have length 1
-      found(0).description === "desc2"
+      found.head.getDescription === "desc2"
     }
     "find empty list if not matching provider" in {
-      val interactions = Seq(Interaction("desc1", Some("providerState1"), mock[Request], mock[Response]))
+      val interactions = Seq(new RequestResponseInteraction("desc1", "providerState1", mock[Request], mock[Response]))
       val runner = createRunner(interactions)
       runner.findInteractions("different") === Nil
     }

--- a/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
@@ -1,8 +1,9 @@
 package com.reagroup.pact.provider
 
 import java.nio.charset.Charset
+import java.util
 
-import au.com.dius.pact.model.Request
+import au.com.dius.pact.model.{OptionalBody, Request}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.springframework.mock.web.MockServletContext
@@ -20,7 +21,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
   "request matcher builder" should {
 
     "build a matcher for http method and path" in {
-      val pactRequest = Request("get", "/hello", None, None, None, None)
+      val pactRequest = new Request("get", "/hello", null, null, OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getMethod === "GET"
@@ -29,7 +30,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for query string" in {
-      val pactRequest = Request("get", "/any", Some("aaa=111&bbb=222"), None, None, None)
+      val pactRequest = new Request("get", "/any", mapAsJavaMap(Map("aaa" -> util.Arrays.asList("111"),"bbb"-> util.Arrays.asList("222"))), null, OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getQueryString === "aaa=111&bbb=222"
@@ -39,25 +40,16 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "decode query string" in {
-      val pactRequest = Request("get", "/any", Some("aaa=%22111%22"), None, None, None)
+      val pactRequest = new Request("get", "/any", mapAsJavaMap(Map("aaa" -> util.Arrays.asList("%22111%22"))),null,OptionalBody.nullBody(),null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
-        request.getQueryString === "aaa=\"111\""
-        request.getParameter("aaa") === "\"111\""
-      }
-    }
-
-    "decode the query string in path" in {
-      val pactRequest = Request("get", "/any?aaa=%22111%22", None, None, None, None)
-      builder.build(pactRequest) must beASuccessfulTry.which { builder =>
-        val request = builder.buildRequest(servletContext)
-        request.getQueryString === "aaa=\"111\""
+        request.getQueryString === "aaa=%22111%22"
         request.getParameter("aaa") === "\"111\""
       }
     }
 
     "build a matcher for normal headers (non-cookie)" in {
-      val pactRequest = Request("get", "/any", None, Some(Map("header1" -> "value1", "header2" -> "value2")), None, None)
+      val pactRequest = new Request("get", "/any", null, mapAsJavaMap(Map("header1" -> "value1", "header2" -> "value2")), OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getHeaderNames.toList === Seq("header1", "header2")
@@ -67,7 +59,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for cookie header" in {
-      val pactRequest = Request("get", "/any", None, Some(Map("Cookie" -> "key1=value1; key2=value2")), None, None)
+      val pactRequest = new Request("get", "/any", null, mapAsJavaMap(Map("Cookie" -> "key1=value1; key2=value2")), OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getCookies must have length 2
@@ -83,7 +75,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for request body" in {
-      val pactRequest = Request("get", "/any", None, None, Some("body1"), None)
+      val pactRequest = new Request("get", "/any", null, null, OptionalBody.body("body1"), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         val body = StreamUtils.copyToString(request.getInputStream, Charset.forName("UTF-8"))


### PR DESCRIPTION
Scala to 2.11.8, Pact to 3.2.12, Spring to 4.3.2. This will enable adding support for new pact features like e.g. reading the pact files from a directory or url.
