### PR TITLE
Enable Context path definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Tells spring where the context file is. Notice we can override some beans in the
 
 ### @PactFile("file:src/pactProviderTest/resources/consumer-project-provider-project.json")
 
-Tells `PactRunner` where the pact file (upload by consumer) is
+Tells `PactRunner` where the pact file (upload by consumer) is. Alternatively one can use the @PactFolder to point the runner towards a directory containing all the pact files, that should be used for the execution.
 
 ### @ProviderState("my-service forbids a request with invalid token")
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Tells spring where the context file is. Notice we can override some beans in the
 
 ### @PactFile("file:src/pactProviderTest/resources/consumer-project-provider-project.json")
 
-Tells `PactRunner` where the pact file (upload by consumer) is. Alternatively one can use the @PactFolder to point the runner towards a directory containing all the pact files, that should be used for the execution.
+Tells `PactRunner` where the pact file (upload by consumer) is. Alternatively one can use the `@PactFolder` to point the runner towards a directory containing all the pact files, that should be used for the execution.
 
 ### @ProviderState("my-service forbids a request with invalid token")
 
@@ -140,6 +140,10 @@ You can use the `uriPathEq` exposed by object `PactRunner` to check if two URIs 
 which may be useful when writing mocking methods.
 
 Say: `http://aaa.com:8888/hello/world` are equal to `https://bbb.com:9999/hello/world` with `uriPathEq`
+
+### @ProviderContextPath
+
+If the container uses a non-null context path, you can use this annotation to specify it so that MockMvc will be instrumented accordingly.
 
 Run the test
 ------------

--- a/build.sbt
+++ b/build.sbt
@@ -1,22 +1,22 @@
 name := "pact-jvm-provider-spring-mvc"
 
-version := "0.4.0"
+version := "0.5.0"
 
 organization := "com.reagroup"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.11.8"
 
 crossScalaVersions := Seq("2.10.4", "2.11.4")
 
-sbtVersion := "0.13.7"
+sbtVersion := "0.13.11"
 
 libraryDependencies ++= Seq(
-  "au.com.dius" %% "pact-jvm-model" % "2.1.13",
-  "au.com.dius" %% "pact-jvm-consumer-junit" % "2.1.13",
-  "org.springframework" % "spring-test" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-webmvc" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-context" % "4.1.3.RELEASE",
-  "org.springframework" % "spring-core" % "4.1.3.RELEASE",
+  "au.com.dius" %% "pact-jvm-model" % "3.2.12",
+  "au.com.dius" %% "pact-jvm-consumer-junit" % "3.2.12",
+  "org.springframework" % "spring-test" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-webmvc" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-context" % "4.3.2.RELEASE",
+  "org.springframework" % "spring-core" % "4.3.2.RELEASE",
   "junit" % "junit" % "4.12",
   "org.skyscreamer" % "jsonassert" % "1.2.3",
   "javax.servlet" % "javax.servlet-api" % "3.0.1",
@@ -26,7 +26,7 @@ libraryDependencies ++= Seq(
 )
 
 // publish to sonatype
-import SonatypeKeys._
+import xerial.sbt.Sonatype.SonatypeKeys._
 
 sonatypeSettings
 

--- a/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
@@ -1,9 +1,14 @@
 package com.reagroup.pact.provider
 
+import java.util
+import java.util.stream.Collectors
+
 import au.com.dius.pact.model.{Interaction, PactReader}
+import org.springframework.core.io.support.ResourcePatternUtils
 import org.springframework.core.io.{DefaultResourceLoader, Resource}
 
 import scala.collection.JavaConversions.asScalaBuffer
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 trait InteractionFileReader {
@@ -11,14 +16,26 @@ trait InteractionFileReader {
   val testClass: Class[_]
 
   lazy val allInteractions: Seq[Interaction] = getPactFile(testClass) match {
-    case Success(pactFile) => asScalaBuffer(PactReader.loadPact(pactFile.getInputStream).getInteractions).toList
+    case Success(pacts) => pacts.flatMap(f => asScalaBuffer(PactReader.loadPact(f.getInputStream).getInteractions).toList)
     case Failure(e) => throw e
   }
 
-  private def getPactFile(klass: Class[_]): Try[Resource] = {
+  private def getPactFile(klass: Class[_]): Try[List[Resource]] = {
+    def readFile(pactFile: PactFile): Resource =
+      new DefaultResourceLoader().getResource(pactFile.value)
+
+    def readFiles(pactFolder: PactFolder): List[Resource] =
+      util.Arrays
+        .stream(ResourcePatternUtils.getResourcePatternResolver(new DefaultResourceLoader()).getResources(pactFolder.value() + "/*.json"))
+        .collect(Collectors.toList[Resource])
+        .asScala
+        .toList
+
+
     Option(klass.getAnnotation(classOf[PactFile]))
-      .map(pactFile => Success(new DefaultResourceLoader().getResource(pactFile.value)))
-      .getOrElse(Failure(new IllegalStateException("Please use @PactFile to specify the pact file resource")))
+      .map(pactFile => Success(List(readFile(pactFile))))
+      .orElse(Option(klass.getAnnotation(classOf[PactFolder])).map(pactFolder => Success(readFiles(pactFolder))))
+      .getOrElse(Failure(new IllegalStateException("Please use @PactFile or @PactFolder to specify the pact file resource")))
   }
 }
 

--- a/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionFileReader.scala
@@ -1,11 +1,9 @@
 package com.reagroup.pact.provider
 
-import java.io.InputStreamReader
-
-import au.com.dius.pact.model.{Interaction, Pact}
+import au.com.dius.pact.model.{Interaction, PactReader}
 import org.springframework.core.io.{DefaultResourceLoader, Resource}
-import org.springframework.util.FileCopyUtils
 
+import scala.collection.JavaConversions.asScalaBuffer
 import scala.util.{Failure, Success, Try}
 
 trait InteractionFileReader {
@@ -13,7 +11,7 @@ trait InteractionFileReader {
   val testClass: Class[_]
 
   lazy val allInteractions: Seq[Interaction] = getPactFile(testClass) match {
-    case Success(pactFile) => Pact.from(readToString(pactFile)).interactions
+    case Success(pactFile) => asScalaBuffer(PactReader.loadPact(pactFile.getInputStream).getInteractions).toList
     case Failure(e) => throw e
   }
 
@@ -22,10 +20,5 @@ trait InteractionFileReader {
       .map(pactFile => Success(new DefaultResourceLoader().getResource(pactFile.value)))
       .getOrElse(Failure(new IllegalStateException("Please use @PactFile to specify the pact file resource")))
   }
-
-  private def readToString(resource: Resource) = {
-    FileCopyUtils.copyToString(new InputStreamReader(resource.getInputStream, "UTF-8"))
-  }
-
 }
 

--- a/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
@@ -29,7 +29,6 @@ trait InteractionRunner {
         case None =>
           val server = standaloneSetup(controller).build()
           val response = server.perform(requestBuilder)
-          println(response)
           responseMatchers(interaction.getResponse).foreach(response.andExpect)
       }
     }

--- a/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
@@ -18,8 +18,8 @@ trait InteractionRunner {
     allInteractions.filter(_.getProviderState == providerState)
   }
 
-  def runReqResponse(interaction: RequestResponseInteraction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
-    RequestMatcherBuilder.build(interaction.getRequest).map { requestBuilder =>
+  def runReqResponse(interaction: RequestResponseInteraction, controller: AnyRef, timeout: Option[Long] = None, contextPath: Option[String]): Try[Unit] = {
+    RequestMatcherBuilder.build(interaction.getRequest, contextPath).map { requestBuilder =>
       timeout match {
         case Some(t) =>
           val server = standaloneSetup(controller).setAsyncRequestTimeout(t).build()
@@ -36,10 +36,10 @@ trait InteractionRunner {
 
   def runMsq(interaction: Message, controller: AnyRef, timeout: Option[Long] = None) = ???
 
-  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
+  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None, contextPath: Option[String]): Try[Unit] = {
     interaction match {
       case requestResponse: RequestResponseInteraction =>
-        runReqResponse(requestResponse, controller, timeout);
+        runReqResponse(requestResponse, controller, timeout, contextPath);
       case msg: Message =>
         runMsq(msg, controller, timeout);
     }

--- a/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/InteractionRunner.scala
@@ -1,48 +1,64 @@
 package com.reagroup.pact.provider
 
-import au.com.dius.pact.model.{Interaction, Response}
+import au.com.dius.pact.model.v3.messaging.Message
+import au.com.dius.pact.model.{Interaction, RequestResponseInteraction, Response}
 import org.springframework.test.web.servlet.ResultMatcher
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders._
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers._
-import org.springframework.test.web.servlet.result.MockMvcResultMatchers.request
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.{request, _}
 import org.springframework.test.web.servlet.setup.MockMvcBuilders._
 
+import scala.collection.JavaConverters._
+import scala.collection.mutable
 import scala.util.Try
 
 trait InteractionRunner {
   this: InteractionFileReader =>
 
   def findInteractions(providerState: String): Seq[Interaction] = {
-    allInteractions.filter(_.providerState.exists(_ == providerState))
+    allInteractions.filter(_.getProviderState == providerState)
   }
 
-  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
-    RequestMatcherBuilder.build(interaction.request).map { requestBuilder =>
+  def runReqResponse(interaction: RequestResponseInteraction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
+    RequestMatcherBuilder.build(interaction.getRequest).map { requestBuilder =>
       timeout match {
-        case Some(t) => {
+        case Some(t) =>
           val server = standaloneSetup(controller).setAsyncRequestTimeout(t).build()
           val asyncStarted = server.perform(requestBuilder).andExpect(request.asyncStarted).andReturn()
           val response = server.perform(asyncDispatch(asyncStarted))
-          responseMatchers(interaction.response).foreach(response.andExpect)
-        }
-        case None => {
+          responseMatchers(interaction.getResponse).foreach(response.andExpect)
+        case None =>
           val server = standaloneSetup(controller).build()
           val response = server.perform(requestBuilder)
-          responseMatchers(interaction.response).foreach(response.andExpect)
-        }
+          println(response)
+          responseMatchers(interaction.getResponse).foreach(response.andExpect)
       }
     }
   }
 
-  private def responseMatchers(response: Response): Seq[ResultMatcher] = {
-    def matchResStatus(response: Response) = status.is(response.status)
-    def matchResBodyAsJson(response: Response) = response.body.map(body => content.json(body))
-    def matchResHeaders(response: Response) = for {
-      headers <- response.headers.toList
-      (name, value) <- headers
-    } yield header.string(name, value)
+  def runMsq(interaction: Message, controller: AnyRef, timeout: Option[Long] = None) = ???
 
-    matchResStatus(response) :: matchResBodyAsJson(response).toList ::: matchResHeaders(response)
+  def runSingle(interaction: Interaction, controller: AnyRef, timeout: Option[Long] = None): Try[Unit] = {
+    interaction match {
+      case requestResponse: RequestResponseInteraction =>
+        runReqResponse(requestResponse, controller, timeout);
+      case msg: Message =>
+        runMsq(msg, controller, timeout);
+    }
+  }
+
+  private def responseMatchers(response: Response): Seq[ResultMatcher] = {
+    def matchResStatus(response: Response)= status.is(response.getStatus)
+    def matchResBodyAsJson(response: Response) = Option(response.getBody.getValue).map(body => content().json(body))
+    def matchResHeaders(response: Response) = {
+      Option(response.getHeaders) match {
+        case None => mutable.Seq.empty
+        case Some(h) => for {
+          headers: (String, String) <- h.asScala
+        } yield header.string(headers._1, headers._2)
+      }
+    }
+
+    matchResStatus(response) :: matchResBodyAsJson(response).toList ::: matchResHeaders(response).toList
   }
 
 }

--- a/src/main/scala/com/reagroup/pact/provider/PactFolder.java
+++ b/src/main/scala/com/reagroup/pact/provider/PactFolder.java
@@ -1,0 +1,13 @@
+package com.reagroup.pact.provider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE})
+public @interface PactFolder {
+
+    String value();
+}

--- a/src/main/scala/com/reagroup/pact/provider/PactRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/PactRunner.scala
@@ -23,7 +23,7 @@ class PactRunner(klass: Class[_]) extends SpringJUnit4ClassRunner(klass: Class[_
     override def evaluate() {
       val controller = method.invokeExplosively(test)
       val providerState = method.getAnnotation(classOf[ProviderState])
-      val contextPath = Option(getTestClass.getAnnotation(classOf[ProviderContextPath]).value())
+      val contextPath = Option(getTestClass.getAnnotation(classOf[ProviderContextPath])).map(_.value())
 
       findInteractions(providerState.value()) match {
         case Nil => fail("Specified ProviderState is not found: " + providerState)

--- a/src/main/scala/com/reagroup/pact/provider/PactRunner.scala
+++ b/src/main/scala/com/reagroup/pact/provider/PactRunner.scala
@@ -23,12 +23,13 @@ class PactRunner(klass: Class[_]) extends SpringJUnit4ClassRunner(klass: Class[_
     override def evaluate() {
       val controller = method.invokeExplosively(test)
       val providerState = method.getAnnotation(classOf[ProviderState])
+      val contextPath = Option(getTestClass.getAnnotation(classOf[ProviderContextPath]).value())
 
       findInteractions(providerState.value()) match {
         case Nil => fail("Specified ProviderState is not found: " + providerState)
         case interactions =>
           val timeout = Some(providerState.deferredResponseInMillis()).filter(_ > 0)
-          interactions.map(runSingle(_, controller, timeout)).foreach {
+          interactions.map(runSingle(_, controller, timeout, contextPath)).foreach {
             case Failure(e) => throw e
             case _ =>
           }

--- a/src/main/scala/com/reagroup/pact/provider/ProviderContextPath.java
+++ b/src/main/scala/com/reagroup/pact/provider/ProviderContextPath.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.METHOD})
+@Target({ElementType.TYPE})
 public @interface ProviderContextPath {
     String value();
 }

--- a/src/main/scala/com/reagroup/pact/provider/ProviderContextPath.java
+++ b/src/main/scala/com/reagroup/pact/provider/ProviderContextPath.java
@@ -1,0 +1,12 @@
+package com.reagroup.pact.provider;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface ProviderContextPath {
+    String value();
+}

--- a/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
+++ b/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
@@ -8,6 +8,7 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders._
 import org.springframework.web.util.{UriComponents, UriComponentsBuilder}
 
+import scala.collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 
 object RequestMatcherBuilder {
@@ -23,16 +24,31 @@ object RequestMatcherBuilder {
   }
 
   private def buildUriComponents(request: Request) = {
-    def decode(s: String) = URLDecoder.decode(s, "UTF-8")
+    def decode(s: String) = {
+      Option(s) match {
+        case Some(q) => URLDecoder.decode(q, "UTF-8")
+        case None => null
+      }
+    }
+
+    def toQuery(map: java.util.Map[String, java.util.List[String]]): String = {
+      Option(map) match {
+        case Some(q) => (for {
+          m <- q.asScala
+        } yield m._1 + "=" + m._2.asScala.map(URLDecoder.decode(_, "UTF-8")).mkString(";")).mkString("&")
+        case None => null
+      }
+    }
+
     UriComponentsBuilder
-      .fromUriString(decode(request.path))
-      .query(request.query.map(decode).getOrElse(""))
+      .fromUriString(decode(request.getPath))
+      .query(decode(toQuery(request.getQuery)))
       .build
   }
 
   private def createBuilderByHttpMethod(request: Request, components: UriComponents): Try[MockHttpServletRequestBuilder] = {
     val uri = components.toUri
-    request.method.toLowerCase match {
+    request.getMethod.toLowerCase match {
       case "get" => Success(get(uri))
       case "post" => Success(post(uri))
       case "put" => Success(put(uri))
@@ -44,20 +60,29 @@ object RequestMatcherBuilder {
   }
 
   private def buildReqBody(builder: MockHttpServletRequestBuilder, request: Request): Unit = {
-    request.body.foreach(body => builder.content(body))
+    Option(request.getBody) match {
+      case Some(b) => builder.content(b.orElse(""))
+      case None =>
+    }
   }
 
-  private def buildReqHeaders(builder: MockHttpServletRequestBuilder, request: Request): Unit = for {
-    headers <- request.headers
-    (name, value) <- headers
-  } builder.header(name, value)
+  private def buildReqHeaders(builder: MockHttpServletRequestBuilder, request: Request): Unit = {
+    Option(request.getHeaders) match {
+      case Some(h) => for {
+        headers: (String, String) <- h.asScala
+      } builder.header(headers._1, headers._2)
+      case None =>
+    }
+  }
 
   private def buildCookies(builder: MockHttpServletRequestBuilder, request: Request, components: UriComponents): Unit = {
-    request.cookie.getOrElse(Nil).map(_.split('=')).collect {
-      case Array(key, value) => new Cookie(key, value)
-    } match {
-      case Nil =>
-      case cookies => builder.cookie(cookies: _*)
+    Option(request.cookie()) match {
+      case Some(c) => c.asScala.map(_.split('=')).collect {
+        case Array(key, value) => new Cookie(key, value)
+      } match {
+        case cookies => builder.cookie(cookies: _*)
+      }
+      case None =>
     }
   }
 

--- a/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
+++ b/src/main/scala/com/reagroup/pact/provider/RequestMatcherBuilder.scala
@@ -13,8 +13,15 @@ import scala.util.{Failure, Success, Try}
 
 object RequestMatcherBuilder {
 
-  def build(request: Request): Try[MockHttpServletRequestBuilder] = {
-    val components = buildUriComponents(request)
+  def build(request: Request, contextPath: Option[String] = None): Try[MockHttpServletRequestBuilder] = {
+    val builder = createBuilder(request, buildUriComponents(request))
+    contextPath match {
+      case Some(path) => builder.map(builder => builder.contextPath(path))
+      case None => builder
+    }
+  }
+
+  private def createBuilder(request: Request, components: UriComponents): Try[MockHttpServletRequestBuilder] = {
     createBuilderByHttpMethod(request, components).map { builder =>
       buildReqHeaders(builder, request)
       buildCookies(builder, request, components)

--- a/src/test/java/sample/MyController.java
+++ b/src/test/java/sample/MyController.java
@@ -19,7 +19,7 @@ public class MyController {
 
     @RequestMapping(value = "/deferred_json", method = RequestMethod.GET, consumes = "application/json", produces = "application/json;charset=UTF-8")
     public DeferredResult<ResponseEntity<String>> defJson() {
-        DeferredResult<ResponseEntity<String>> result = new DeferredResult<ResponseEntity<String>>(50);
+        DeferredResult<ResponseEntity<String>> result = new DeferredResult<>(50L);
         ResponseEntity<String> response = myResponseService.getResponse();
         result.setResult(response);
         return result;

--- a/src/test/resources/interactions.json
+++ b/src/test/resources/interactions.json
@@ -98,5 +98,10 @@
         }
       }
     }
-  ]
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    }
+  }
 }

--- a/src/test/resources/pacts/interaction_1.json
+++ b/src/test/resources/pacts/interaction_1.json
@@ -1,0 +1,32 @@
+{
+  "provider": {
+    "name": "provider-side"
+  },
+  "consumer": {
+    "name": "consumer-side"
+  },
+  "interactions": [
+    {
+      "provider_state": "state 1",
+      "description": "description1",
+      "request": {
+        "method": "get",
+        "path": "/json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "hello": "world"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/src/test/resources/pacts/interaction_2.json
+++ b/src/test/resources/pacts/interaction_2.json
@@ -1,0 +1,32 @@
+{
+  "provider": {
+    "name": "provider-side"
+  },
+  "consumer": {
+    "name": "consumer-side"
+  },
+  "interactions": [
+    {
+      "provider_state": "state 2",
+      "description": "description1",
+      "request": {
+        "method": "get",
+        "path": "/json",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      },
+      "response": {
+        "status": 200,
+        "body": {
+          "hello": "world"
+        }
+      }
+    }
+  ],
+  "metadata": {
+    "pact-specification": {
+      "version": "2.0.0"
+    }
+  }
+}

--- a/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
@@ -21,10 +21,18 @@ class InteractionFileReaderTest extends Specification with Mockito {
       val reader = createReader(classOf[TestClassWithoutPactFileAnnotation])
       reader.allInteractions should throwA[IllegalStateException]
     }
+    "read interactions from different JSON files in a directory" in {
+      val reader = createReader(classOf[TestClassWithFolder])
+      reader.allInteractions must have length 2
+      reader.allInteractions.map(_.getProviderState) === Seq("state 1", "state 2")
+    }
   }
 
   @PactFile("file:src/test/resources/interactions.json")
   class TestClass
+
+  @PactFolder("file:src/test/resources/pacts")
+  class TestClassWithFolder
 
   @PactFile("file:src/test/resources/not-found-file.json")
   class TestClassWithFileNotFound

--- a/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/InteractionFileReaderTest.scala
@@ -11,7 +11,7 @@ class InteractionFileReaderTest extends Specification with Mockito {
     "read interactions from the JSON file" in {
       val reader = createReader(classOf[TestClass])
       reader.allInteractions must have length 5
-      reader.allInteractions.map(_.providerState) === Seq(Some("normal"), Some("deferred"), Some("with-headers"), Some("with-cookies"), Some("with-array-body"))
+      reader.allInteractions.map(_.getProviderState) === Seq("normal", "deferred", "with-headers", "with-cookies", "with-array-body")
     }
     "should report error if file is not found" in {
       val reader = createReader(classOf[TestClassWithFileNotFound])

--- a/src/test/scala/com/reagroup/pact/provider/InteractionRunnerTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/InteractionRunnerTest.scala
@@ -1,6 +1,6 @@
 package com.reagroup.pact.provider
 
-import au.com.dius.pact.model.{Interaction, Request, Response}
+import au.com.dius.pact.model.{Interaction, Request, RequestResponseInteraction, Response}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 
@@ -9,16 +9,16 @@ class InteractionRunnerTest extends Specification with Mockito {
   "InteractionRunner" should {
     "find interactions by provider state" in {
       val interactions = Seq(
-        Interaction("desc1", Some("providerState1"), mock[Request], mock[Response]),
-        Interaction("desc2", Some("providerState2"), mock[Request], mock[Response]))
+        new RequestResponseInteraction("desc1", "providerState1", mock[Request], mock[Response]),
+        new RequestResponseInteraction("desc2", "providerState2", mock[Request], mock[Response]))
       val runner = createRunner(interactions)
 
       val found = runner.findInteractions("providerState2")
       found must have length 1
-      found(0).description === "desc2"
+      found.head.getDescription === "desc2"
     }
     "find empty list if not matching provider" in {
-      val interactions = Seq(Interaction("desc1", Some("providerState1"), mock[Request], mock[Response]))
+      val interactions = Seq(new RequestResponseInteraction("desc1", "providerState1", mock[Request], mock[Response]))
       val runner = createRunner(interactions)
       runner.findInteractions("different") === Nil
     }

--- a/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
@@ -1,8 +1,9 @@
 package com.reagroup.pact.provider
 
 import java.nio.charset.Charset
+import java.util
 
-import au.com.dius.pact.model.Request
+import au.com.dius.pact.model.{OptionalBody, Request}
 import org.specs2.mock.Mockito
 import org.specs2.mutable.Specification
 import org.springframework.mock.web.MockServletContext
@@ -20,7 +21,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
   "request matcher builder" should {
 
     "build a matcher for http method and path" in {
-      val pactRequest = Request("get", "/hello", None, None, None, None)
+      val pactRequest = new Request("get", "/hello", null, null, OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getMethod === "GET"
@@ -29,7 +30,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for query string" in {
-      val pactRequest = Request("get", "/any", Some("aaa=111&bbb=222"), None, None, None)
+      val pactRequest = new Request("get", "/any", mapAsJavaMap(Map("aaa" -> util.Arrays.asList("111"),"bbb"-> util.Arrays.asList("222"))), null, OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getQueryString === "aaa=111&bbb=222"
@@ -39,25 +40,16 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "decode query string" in {
-      val pactRequest = Request("get", "/any", Some("aaa=%22111%22"), None, None, None)
+      val pactRequest = new Request("get", "/any", mapAsJavaMap(Map("aaa" -> util.Arrays.asList("%22111%22"))),null,OptionalBody.nullBody(),null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
-        request.getQueryString === "aaa=\"111\""
-        request.getParameter("aaa") === "\"111\""
-      }
-    }
-
-    "decode the query string in path" in {
-      val pactRequest = Request("get", "/any?aaa=%22111%22", None, None, None, None)
-      builder.build(pactRequest) must beASuccessfulTry.which { builder =>
-        val request = builder.buildRequest(servletContext)
-        request.getQueryString === "aaa=\"111\""
+        request.getQueryString === "aaa=%22111%22"
         request.getParameter("aaa") === "\"111\""
       }
     }
 
     "build a matcher for normal headers (non-cookie)" in {
-      val pactRequest = Request("get", "/any", None, Some(Map("header1" -> "value1", "header2" -> "value2")), None, None)
+      val pactRequest = new Request("get", "/any", null, mapAsJavaMap(Map("header1" -> "value1", "header2" -> "value2")), OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getHeaderNames.toList === Seq("header1", "header2")
@@ -67,7 +59,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for cookie header" in {
-      val pactRequest = Request("get", "/any", None, Some(Map("Cookie" -> "key1=value1; key2=value2")), None, None)
+      val pactRequest = new Request("get", "/any", null, mapAsJavaMap(Map("Cookie" -> "key1=value1; key2=value2")), OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         request.getCookies must have length 2
@@ -83,7 +75,7 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
     }
 
     "build a matcher for request body" in {
-      val pactRequest = Request("get", "/any", None, None, Some("body1"), None)
+      val pactRequest = new Request("get", "/any", null, null, OptionalBody.body("body1"), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>
         val request = builder.buildRequest(servletContext)
         val body = StreamUtils.copyToString(request.getInputStream, Charset.forName("UTF-8"))

--- a/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/RequestMatcherBuilderTest.scala
@@ -29,6 +29,14 @@ class RequestMatcherBuilderTest extends Specification with Mockito {
       }
     }
 
+    "build a matcher using provided contextPath" in {
+      val pactRequest = new Request("get", "/contextPathProvidedByTheContainer/hello", null, null, OptionalBody.nullBody(), null)
+      builder.build(pactRequest, Some("/contextPathProvidedByTheContainer")) must beASuccessfulTry.which { builder =>
+        val request = builder.buildRequest(servletContext)
+        request.getContextPath === "/contextPathProvidedByTheContainer"
+      }
+    }
+
     "build a matcher for query string" in {
       val pactRequest = new Request("get", "/any", mapAsJavaMap(Map("aaa" -> util.Arrays.asList("111"),"bbb"-> util.Arrays.asList("222"))), null, OptionalBody.nullBody(), null)
       builder.build(pactRequest) must beASuccessfulTry.which { builder =>

--- a/src/test/scala/com/reagroup/pact/provider/ResponseCheckingTest.scala
+++ b/src/test/scala/com/reagroup/pact/provider/ResponseCheckingTest.scala
@@ -31,7 +31,7 @@ class ResponseCheckingTest extends Specification with Mockito {
   "non-deferred response checking" should {
     def testWithResponse(response: ResponseEntity[String]) = {
       myResponseService.getResponse[String] returns response
-      val result = pactRunner.runSingle(SampleInteraction, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteraction, myControllerWithService, contextPath = None)
       result must beASuccessfulTry
     }
     "pass if response matches expected exactly" in testWithResponse {
@@ -45,7 +45,7 @@ class ResponseCheckingTest extends Specification with Mockito {
     }
     "pass if required request cookies are also matched" in {
       myResponseService.getResponseForCookies[String](Array("value1", "value2")) returns new ResponseEntity[String]( """{ "hello": "world" }""", HttpStatus.OK)
-      val result = pactRunner.runSingle(SampleInteractionWithCookies, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteractionWithCookies, myControllerWithService, contextPath = None)
       result must beASuccessfulTry
     }
   }
@@ -54,7 +54,7 @@ class ResponseCheckingTest extends Specification with Mockito {
     "pass if response matches expected exactly" in {
       val response = new ResponseEntity[String]( """{ "hello": "world" }""", HttpStatus.OK)
       myResponseService.getResponse[String] returns response
-      val result = pactRunner.runSingle(SampleDeferredInteraction, myControllerWithService, timeout = Some(200))
+      val result = pactRunner.runSingle(SampleDeferredInteraction, myControllerWithService, timeout = Some(200), contextPath = None)
       result must beASuccessfulTry
     }
   }
@@ -62,31 +62,31 @@ class ResponseCheckingTest extends Specification with Mockito {
   "non-deferred response checking" should {
     "fail if status is not equal" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": "world" }""", HttpStatus.INTERNAL_SERVER_ERROR)
-      val result = pactRunner.runSingle(SampleInteraction, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteraction, myControllerWithService, contextPath = None)
       result must beAFailedTry.which(_.getMessage === "Response status expected:<200> but was:<500>")
     }
 
     "fail if required header is missing" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": "world" }""", HttpStatus.OK)
-      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService, contextPath = None)
       result must beAFailedTry.which(_.getMessage === "Response header my-header1 expected:<my-value1> but was:<null>")
     }
 
     "fail if header value is not equal" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": "world" }""", createHeaders("my-header1" -> "different-value"), HttpStatus.OK)
-      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService, contextPath = None)
       result must beAFailedTry.which(_.getMessage === "Response header my-header1 expected:<my-value1> but was:<different-value>")
     }
 
     "fail if header value is not equal to expected case sensitively" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": "world" }""", createHeaders("my-header1" -> "MY-VALUE1"), HttpStatus.OK)
-      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteractionWithHeaders, myControllerWithService, contextPath = None)
       result must beAFailedTry.which(_.getMessage === "Response header my-header1 expected:<my-value1> but was:<MY-VALUE1>")
     }
 
     "fail if array in body contains unexpected item" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": ["world1", "world2", "unexpected-item-here"]}""", HttpStatus.OK)
-      val result = pactRunner.runSingle(SampleInteractionWithArrayBody, myControllerWithService)
+      val result = pactRunner.runSingle(SampleInteractionWithArrayBody, myControllerWithService, contextPath = None)
       result must beAFailedTry.which(_.getMessage === "hello[]: Expected 2 values but got 3")
     }
   }
@@ -94,7 +94,7 @@ class ResponseCheckingTest extends Specification with Mockito {
   "deferred response checking" should {
     "fail if status is not equal" in {
       myResponseService.getResponse[String] returns new ResponseEntity[String]( """{ "hello": "world" }""", HttpStatus.INTERNAL_SERVER_ERROR)
-      val result = pactRunner.runSingle(SampleDeferredInteraction, myControllerWithService, timeout = Some(200))
+      val result = pactRunner.runSingle(SampleDeferredInteraction, myControllerWithService, timeout = Some(200), contextPath = None)
       result must beAFailedTry.which(_.getMessage === "Response status expected:<200> but was:<500>")
     }
   }


### PR DESCRIPTION
This provides an `@ProviderContextPath` annotation. Now it's possible to define the context path of the container. This PR is based on https://github.com/realestate-com-au/pact-jvm-provider-spring-mvc/pull/1 and https://github.com/realestate-com-au/pact-jvm-provider-spring-mvc/pull/2
