### PR TITLE
Update sbt launcher to fetch location

### DIFF
--- a/sbt
+++ b/sbt
@@ -115,7 +115,7 @@ declare -r script_name="${script_path##*/}"
 declare java_cmd="java"
 declare sbt_opts_file="$(init_default_option_file SBT_OPTS .sbtopts)"
 declare jvm_opts_file="$(init_default_option_file JVM_OPTS .jvmopts)"
-declare sbt_launch_repo="http://typesafe.artifactoryonline.com/typesafe/ivy-releases"
+declare sbt_launch_repo="https://repo.typesafe.com/typesafe/ivy-releases"
 
 # pull -J and -D options to give to java.
 declare -a residual_args
@@ -195,7 +195,7 @@ download_url () {
 
   mkdir -p "${jar%/*}" && {
     if which curl >/dev/null; then
-      curl --fail --silent "$url" --output "$jar"
+      curl --fail --silent --location "$url" --output "$jar"
     elif which wget >/dev/null; then
       wget --quiet -O "$jar" "$url"
     fi


### PR DESCRIPTION
A while back, typesafe changed their download location for the sbt launcher (https://github.com/foundweekends/conscript/issues/73)

This change switches over to use this location and also updates the `curl` to follow redirect.  We'll need this merged in before @psalchow can apply this PR: https://github.com/realestate-com-au/pact-jvm-provider-spring-mvc/pull/5
